### PR TITLE
Fix block loot tables

### DIFF
--- a/src/generated/resources/.cache/1cc437e1eea09444a2213e11c592b4aed4793e2f
+++ b/src/generated/resources/.cache/1cc437e1eea09444a2213e11c592b4aed4793e2f
@@ -116,4 +116,4 @@ ff2732c8e862bc38cae51d810c8f18fbcc72bc11 data/goety/loot_tables/blocks/trapped_h
 0d6fd8f0fc3dab9ac3eedcb50e8e8e24e2bb4753 data/goety/loot_tables/blocks/trapped_rotten_chest.json
 7dba1958edef1656ec77c718e4afc766e4f45610 data/goety/loot_tables/blocks/wind_blower.json
 dbc604b3613797556c5d513051c76355f3769e9f data/goety/loot_tables/blocks/witch_cauldron.json
-710aa9aeb401ccf1ab250d15ba634dbdb6b7d33b data/goety/loot_tables/blocks/witch_pole.json
+91b84bdce49685ec5710e641f57cd2e162f55100 data/goety/loot_tables/blocks/witch_pole.json

--- a/src/generated/resources/.cache/1cc437e1eea09444a2213e11c592b4aed4793e2f
+++ b/src/generated/resources/.cache/1cc437e1eea09444a2213e11c592b4aed4793e2f
@@ -1,4 +1,4 @@
-// 1.19.2	2023-10-28T11:12:50.1351829	Goety LootTables
+// 1.19.2	2023-11-18T17:59:39.233154189	Goety LootTables
 e6879298f9301398dfd05e679517cfe1dbed62fb data/goety/loot_tables/blocks/arca.json
 91780276c14aaa3e2781a35cd47e57fccb5e5497 data/goety/loot_tables/blocks/blackstone_brazier.json
 010339b95e66d49740dc94c37972afad9a7ab5cc data/goety/loot_tables/blocks/brick_brazier.json
@@ -32,6 +32,7 @@ b4318aba59c2101a47afc4c5d56af946c1df16d2 data/goety/loot_tables/blocks/cursed_in
 92213c811f68be918a1a66d8a4ba534823dfe8e1 data/goety/loot_tables/blocks/dark_altar.json
 5db1a7f6465e292705039cd03dd04ed114328996 data/goety/loot_tables/blocks/dark_anvil.json
 8e83a2a7dbcc5ff9ff73f328e5828c8086ed345b data/goety/loot_tables/blocks/dark_metal_block.json
+faea109ae464c8d7e4939f5a598bfd63c68c91f2 data/goety/loot_tables/blocks/dark_pressure_plate.json
 ea197e7bc93a8e95f63634cb41535e23825f98d9 data/goety/loot_tables/blocks/deepslate_brazier.json
 086f7328883dd9e007d7613b3891e99fcc33e231 data/goety/loot_tables/blocks/forbidden_grass.json
 cad5d3f89e0886fe6b0b3a907dde082b5fde386a data/goety/loot_tables/blocks/haunted_bookshelf.json

--- a/src/generated/resources/data/goety/loot_tables/blocks/dark_pressure_plate.json
+++ b/src/generated/resources/data/goety/loot_tables/blocks/dark_pressure_plate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "goety:dark_pressure_plate"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/generated/resources/data/goety/loot_tables/blocks/witch_pole.json
+++ b/src/generated/resources/data/goety/loot_tables/blocks/witch_pole.json
@@ -11,6 +11,15 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "goety:witch_pole",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
           "name": "goety:witch_pole"
         }
       ],

--- a/src/main/java/com/Polarice3/Goety/data/ModBlockLootProvider.java
+++ b/src/main/java/com/Polarice3/Goety/data/ModBlockLootProvider.java
@@ -2,6 +2,7 @@ package com.Polarice3.Goety.data;
 
 import com.Polarice3.Goety.common.blocks.ModBlocks;
 import com.Polarice3.Goety.common.blocks.SnapWartsBlock;
+import com.Polarice3.Goety.common.blocks.WitchPoleBlock;
 import com.Polarice3.Goety.common.items.ModItems;
 import net.minecraft.advancements.critereon.EnchantmentPredicate;
 import net.minecraft.advancements.critereon.ItemPredicate;
@@ -16,6 +17,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.SlabBlock;
+import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
@@ -71,6 +73,8 @@ public class ModBlockLootProvider extends ModBaseLootProvider{
                     this.add(block, BlockLoot::createDoorTable);
                 } else if (block instanceof SlabBlock){
                     this.add(block, BlockLoot::createSlabItemTable);
+                } else if (block instanceof WitchPoleBlock) {
+                    this.add(block, bl -> createSinglePropConditionTable(bl, WitchPoleBlock.HALF, DoubleBlockHalf.LOWER));
                 } else {
                     this.dropSelf(block);
                 }


### PR DESCRIPTION
I fixed witch pole's loot table (it was dropping two poles when broken), then found out that dark pressure plate loot table was not generated, so I committed that as well.