### PR TITLE
Fix item duplication via enchanting ritual

### DIFF
--- a/src/main/java/com/Polarice3/Goety/common/ritual/EnchantItemRitual.java
+++ b/src/main/java/com/Polarice3/Goety/common/ritual/EnchantItemRitual.java
@@ -81,6 +81,8 @@ public class EnchantItemRitual extends Ritual{
         if (result.getItem() instanceof BookItem){
             result = EnchantedBookItem.createForEnchantment(enchantmentInstance);
             activationItem.shrink(1);
+            IItemHandler handler = tileEntity.itemStackHandler.orElseThrow(RuntimeException::new);
+            handler.insertItem(0, result, false);
         } else {
             if (map.containsKey(this.recipe.getEnchantment())) {
                 for (Enchantment enchantment : map.keySet()) {
@@ -102,7 +104,5 @@ public class EnchantItemRitual extends Ritual{
             }
         }
         result.onCraftedBy(world, castingPlayer, 1);
-        IItemHandler handler = tileEntity.itemStackHandler.orElseThrow(RuntimeException::new);
-        handler.insertItem(0, result, false);
     }
 }


### PR DESCRIPTION
Currently, any **stackable** item is duplicated after enchanting via enchanting ritual. You can test this in vanilla by enchanting carved pumpkin with curse of binding. This PR fixes it.

Dev notes: inserting item is only needed for books, because you create a new stack. In other cases, you modify existing stack and don't need to insert it once more.