### PR TITLE
Only check for curios on entities that are players in fireImmune mixin

### DIFF
--- a/src/main/java/com/Polarice3/Goety/mixin/EntityMixin.java
+++ b/src/main/java/com/Polarice3/Goety/mixin/EntityMixin.java
@@ -104,8 +104,8 @@ public abstract class EntityMixin {
     @Inject(method = "fireImmune", at = @At("HEAD"), cancellable = true)
     public void fireImmune(CallbackInfoReturnable<Boolean> callbackInfoReturnable) {
         Entity entity = (Entity) (Object) this;
-        if (entity instanceof LivingEntity livingEntity){
-            if (CuriosFinder.hasUnholyHat(livingEntity) || CuriosFinder.hasUnholyRobe(livingEntity)){
+        if (entity instanceof Player player){
+            if (CuriosFinder.hasUnholyHat(player) || CuriosFinder.hasUnholyRobe(player)){
                 callbackInfoReturnable.setReturnValue(true);
             }
         }


### PR DESCRIPTION
This check is inexpensive once or twice, but with a lot of entities this gets duplicated on all of them and causes performance issues. There shouldn't be any reason to check of Zombies or Horses have Unholy Hat or Unholy Robes...