### PR TITLE
Remove confusing slot handling

### DIFF
--- a/src/main/java/com/Polarice3/Goety/common/items/handler/BrewBagItemHandler.java
+++ b/src/main/java/com/Polarice3/Goety/common/items/handler/BrewBagItemHandler.java
@@ -3,8 +3,6 @@ package com.Polarice3.Goety.common.items.handler;
 import com.Polarice3.Goety.common.items.brew.ThrowableBrewItem;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.items.IItemHandler;
@@ -14,56 +12,19 @@ import javax.annotation.Nonnull;
 
 public class BrewBagItemHandler extends ItemStackHandler {
     private final ItemStack itemStack;
-    private int slot;
 
     public BrewBagItemHandler(ItemStack itemStack) {
         super(11);
         this.itemStack = itemStack;
     }
 
-    public ItemStack extractItem() {
-        return extractItem(slot, 1, false);
-    }
-
-    public ItemStack insertItem(ItemStack insert) {
-        return insertItem(slot, insert, false);
-    }
-
-    public ItemStack getSlot() {
-        return getStackInSlot(slot);
-    }
-
     @Override
-    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
-    {
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
         return stack.getItem() instanceof ThrowableBrewItem;
     }
 
-    public NonNullList<ItemStack> getContents(){
+    public NonNullList<ItemStack> getContents() {
         return stacks;
-    }
-
-    @Override
-    public CompoundTag serializeNBT() {
-        CompoundTag nbt = super.serializeNBT();
-        nbt.putInt("slot", slot);
-        return nbt;
-    }
-
-    @Override
-    public void deserializeNBT(CompoundTag nbt) {
-        super.deserializeNBT(nbt);
-        ListTag tagList = nbt.getList("Items", Tag.TAG_COMPOUND);
-        for (int i = 0; i < tagList.size(); i++)
-        {
-            CompoundTag itemTags = tagList.getCompound(i);
-            if (nbt.contains("slot")) {
-                slot = nbt.getInt("slot");
-                stacks.set(slot, ItemStack.of(itemTags));
-            }
-        }
-        onLoad();
-
     }
 
     @Override

--- a/src/main/java/com/Polarice3/Goety/common/items/handler/FocusBagItemHandler.java
+++ b/src/main/java/com/Polarice3/Goety/common/items/handler/FocusBagItemHandler.java
@@ -3,8 +3,6 @@ package com.Polarice3.Goety.common.items.handler;
 import com.Polarice3.Goety.api.items.magic.IFocus;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.items.IItemHandler;
@@ -15,24 +13,11 @@ import javax.annotation.Nonnull;
 public class FocusBagItemHandler extends ItemStackHandler {
     private final ItemStack itemStack;
     private final int size;
-    private int slot;
 
     public FocusBagItemHandler(ItemStack itemStack, int size) {
         super(size);
         this.size = size;
         this.itemStack = itemStack;
-    }
-
-    public ItemStack extractItem() {
-        return extractItem(slot, 1, false);
-    }
-
-    public ItemStack insertItem(ItemStack insert) {
-        return insertItem(slot, insert, false);
-    }
-
-    public ItemStack getSlot() {
-        return getStackInSlot(slot);
     }
 
     @Override
@@ -45,31 +30,8 @@ public class FocusBagItemHandler extends ItemStackHandler {
         return this.size;
     }
 
-    public NonNullList<ItemStack> getContents(){
+    public NonNullList<ItemStack> getContents() {
         return stacks;
-    }
-
-    @Override
-    public CompoundTag serializeNBT() {
-        CompoundTag nbt = super.serializeNBT();
-        nbt.putInt("slot", slot);
-        return nbt;
-    }
-
-    @Override
-    public void deserializeNBT(CompoundTag nbt) {
-        super.deserializeNBT(nbt);
-        ListTag tagList = nbt.getList("Items", Tag.TAG_COMPOUND);
-        for (int i = 0; i < tagList.size(); i++)
-        {
-            CompoundTag itemTags = tagList.getCompound(i);
-            if (nbt.contains("slot")) {
-                slot = nbt.getInt("slot");
-                stacks.set(slot, ItemStack.of(itemTags));
-            }
-        }
-        onLoad();
-
     }
 
     @Override

--- a/src/main/java/com/Polarice3/Goety/common/items/handler/SoulUsingItemHandler.java
+++ b/src/main/java/com/Polarice3/Goety/common/items/handler/SoulUsingItemHandler.java
@@ -3,8 +3,6 @@ package com.Polarice3.Goety.common.items.handler;
 import com.Polarice3.Goety.api.items.magic.IFocus;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.items.IItemHandler;
@@ -14,27 +12,25 @@ import javax.annotation.Nonnull;
 
 public class SoulUsingItemHandler extends ItemStackHandler {
     private final ItemStack itemStack;
-    private int slot;
 
     public SoulUsingItemHandler(ItemStack itemStack) {
         this.itemStack = itemStack;
     }
 
     public ItemStack extractItem() {
-        return extractItem(slot, 1, false);
+        return extractItem(0, 1, false);
     }
 
     public ItemStack insertItem(ItemStack insert) {
-        return insertItem(slot, insert, false);
+        return insertItem(0, insert, false);
     }
 
     public ItemStack getSlot() {
-        return getStackInSlot(slot);
+        return getStackInSlot(0);
     }
 
     @Override
-    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
-    {
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
         return stack.getItem() instanceof IFocus;
     }
 
@@ -43,31 +39,8 @@ public class SoulUsingItemHandler extends ItemStackHandler {
         return 1;
     }
 
-    public NonNullList<ItemStack> getContents(){
+    public NonNullList<ItemStack> getContents() {
         return stacks;
-    }
-
-    @Override
-    public CompoundTag serializeNBT() {
-        CompoundTag nbt = super.serializeNBT();
-        nbt.putInt("slot", slot);
-        return nbt;
-    }
-
-    @Override
-    public void deserializeNBT(CompoundTag nbt) {
-        super.deserializeNBT(nbt);
-        ListTag tagList = nbt.getList("Items", Tag.TAG_COMPOUND);
-        for (int i = 0; i < tagList.size(); i++)
-        {
-            CompoundTag itemTags = tagList.getCompound(i);
-            if (nbt.contains("slot")) {
-                slot = nbt.getInt("slot");
-                stacks.set(slot, ItemStack.of(itemTags));
-            }
-        }
-        onLoad();
-
     }
 
     @Override

--- a/src/main/java/com/Polarice3/Goety/common/items/handler/WitchStaffItemHandler.java
+++ b/src/main/java/com/Polarice3/Goety/common/items/handler/WitchStaffItemHandler.java
@@ -2,8 +2,6 @@ package com.Polarice3.Goety.common.items.handler;
 
 import com.Polarice3.Goety.common.items.brew.BrewItem;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.items.IItemHandler;
@@ -13,50 +11,26 @@ import javax.annotation.Nonnull;
 
 public class WitchStaffItemHandler extends ItemStackHandler {
     private final ItemStack itemStack;
-    private int slot;
 
     public WitchStaffItemHandler(ItemStack itemStack) {
         this.itemStack = itemStack;
     }
 
     public ItemStack extractItem() {
-        return extractItem(slot, 1, false);
+        return extractItem(0, 1, false);
     }
 
     public ItemStack insertItem(ItemStack insert) {
-        return insertItem(slot, insert, false);
+        return insertItem(0, insert, false);
     }
 
     public ItemStack getSlot() {
-        return getStackInSlot(slot);
+        return getStackInSlot(0);
     }
 
     @Override
     public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
         return stack.getItem() instanceof BrewItem;
-    }
-
-    @Override
-    public CompoundTag serializeNBT() {
-        CompoundTag nbt = super.serializeNBT();
-        nbt.putInt("slot", slot);
-        return nbt;
-    }
-
-    @Override
-    public void deserializeNBT(CompoundTag nbt) {
-        super.deserializeNBT(nbt);
-        ListTag tagList = nbt.getList("Items", Tag.TAG_COMPOUND);
-        for (int i = 0; i < tagList.size(); i++)
-        {
-            CompoundTag itemTags = tagList.getCompound(i);
-            if (nbt.contains("slot")) {
-                slot = nbt.getInt("slot");
-                stacks.set(slot, ItemStack.of(itemTags));
-            }
-        }
-        onLoad();
-
     }
 
     @Override


### PR DESCRIPTION
The slot field is always 0, and its related methods (extractItem, insertItem, getSlot) are unused.
The deserializeNBT method has flawed logic: it iterates through all items in the NBT data but only ever writes the last one into slot 0, effectively discarding the rest.
Additionally, the goety-dirty NBT tag is unused elsewhere and its purpose is unclear.
I have removed the slot-related code. The goety-dirty tag is also ambiguous; I am unsure if it should be removed as well.