### PR TITLE
Fix Cursed Cage cross-dimension owner lookup and soul discount

### DIFF
--- a/src/main/java/com/Polarice3/Goety/common/blocks/entities/CursedCageBlockEntity.java
+++ b/src/main/java/com/Polarice3/Goety/common/blocks/entities/CursedCageBlockEntity.java
@@ -55,6 +55,9 @@ public class CursedCageBlockEntity extends BlockEntity implements Clearable {
         if (this.item.getItem() == ModItems.SOUL_TRANSFER.get() && this.item.getTag() != null) {
             if (this.item.getTag().contains("owner")) {
                 UUID owner = this.item.getTag().getUUID("owner");
+                if (this.level instanceof ServerLevel serverLevel) {
+                    return serverLevel.getServer().getPlayerList().getPlayer(owner);
+                }
                 return this.level.getPlayerByUUID(owner);
             }
         }
@@ -66,7 +69,10 @@ public class CursedCageBlockEntity extends BlockEntity implements Clearable {
             Player player = this.getOwner();
             if (player != null) {
                 if (SEHelper.getSEActive(player)) {
-                    return SEHelper.getSESouls(player);
+                    int seSouls = SEHelper.getSESouls(player);
+                    if (seSouls > 0) {
+                        return seSouls;
+                    }
                 }
             }
             if (this.item.getItem() instanceof ITotem) {
@@ -97,7 +103,7 @@ public class CursedCageBlockEntity extends BlockEntity implements Clearable {
                 if (SEHelper.getSEActive(player)) {
                     int Soulcount = SEHelper.getSESouls(player);
                     if (Soulcount > 0) {
-                        SEHelper.decreaseSESouls(player, souls);
+                        SEHelper.decreaseSouls(player, souls);
                         SEHelper.sendSEUpdatePacket(player);
                         ArcaBlockEntity arcaTile = (ArcaBlockEntity) this.level.getBlockEntity(SEHelper.getArcaBlock(player));
                         if (arcaTile != null) {


### PR DESCRIPTION
修复诅咒之笼跨维度主人查找和灵魂折扣问题

These three bugs were found, fixed, and verified in the yzzzfix mod deployed with 勇者之章3 (Chapter of Yuusha)

三个修复均来自勇者之章3整合包中的 yzzzfix 模组

1. Cross-dimension getOwner() The cage called level.getPlayerByUUID(), which only searches the current dimension. If the owner was in the Nether while the cage was in the Overworld, it returned null — cage just stopped. Now it goes through ServerPlayerList for a global lookup.

   诅咒之笼找主人用了 getPlayerByUUID()，这个方法只搜当前维度。主人在下界、 笼子在主世界的时候直接返回 null，笼子就废了。现在改成走 ServerPlayerList 全局查找。

2. Armor soul discount not applied decreaseSouls() was calling SEHelper.decreaseSESouls(), which deducts the raw amount. Spells use SEHelper.decreaseSouls() which respects ISoulDiscount on armor. So armor discount worked for casting spells but was silently ignored by the cage. Fixed by switching to the same method spells use.

   诅咒之笼扣灵魂直接用了 decreaseSESouls()，这个方法不经过折扣计算，扣多少 就是多少。法术走的是 decreaseSouls()，会先算护甲的 ISoulDiscount 减免。 结果就是——护甲折扣对施法有效，对笼子无效，同一个玩家的灵魂， 改成了跟法术用同一个方法。

3. getSouls() ignored totem when SE was drained getSouls() checks if the owner's Arca is active — if yes, it returns the Arca soul count. But when the Arca was drained to 0, the method returned 0 without ever checking the totem inside the cage. The cage would sit there idle with a loaded totem just because the Arca was empty. Now if Arca returns 0, it falls through to the totem NBT check.

   getSouls() 的逻辑是：主人的灵魂方舟激活 → 返回方舟里的灵魂能量。问题在于 方舟里的灵魂花光了、变成 0 了，它就真的返回 0，完全不管诅咒笼子里插的图腾 还有没有灵魂。图腾里的魂被活活无视了。现在改成方舟返回 0 的时候不直接 放弃，继续检查图腾 NBT 兜底。